### PR TITLE
Add Vial note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ This board is fully compatible with QMK. This is a default QMK configuration, so
 	
 Check [here](https://github.com/qmk/qmk_firmware/tree/master/keyboards/ashpil/modelm_usbc "QMK profile") for details.
 
+Alternatively you can use the [Vial](https://get.vial.today/) firmware. Setup is analogous to QMK, clone the Vial repo and run:
+	
+	make ashpil/modelm_usbc:vial:flash
+
 ## Other
 
 If you have any problems/comments, or find anything that could be improved, please submit issue or a pull request!


### PR DESCRIPTION
Hi! I just got my hands on a PCB from this project and wanted to contribute by providing Vial firmware support.
My [PR](https://github.com/vial-kb/vial-qmk/pull/472) in the Vial repo is still pending merging, so I'd wait to merge this PR here too, until that happened.

For those unaware, Vial is a QMK fork that supports re-binding keys via a GUI and much more. Similar to VIA.
